### PR TITLE
Phase 2 security baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "composer"
+    directory: "/php"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+---
+
+name: CodeQL Analysis
+
+'on':
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 5 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python, php
+          config: |
+            paths:
+              - python
+              - php
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,49 @@
+---
+
+name: Security Audits
+
+'on':
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pip-audit
+
+      - name: Run pip-audit
+        run: pip-audit -r python/requirements.txt
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          coverage: 'none'
+          extensions: dom, xmlwriter
+
+      - name: Install Composer dependencies
+        working-directory: php
+        run: composer install --no-interaction --no-progress
+
+      - name: Run composer audit
+        working-directory: php
+        run: composer audit --no-interaction

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+We take the security of the unofficial CourtListener SDK seriously. This document explains how to report vulnerabilities, what to expect from us, and how we automate security checks inside this repository.
+
+## Supported Versions
+
+| Version  | Supported |
+|----------|-----------|
+| `main`   | ✅
+| Released tags within the past 6 months | ✅
+| Anything older | ⚠️ Best effort only |
+
+Security fixes are developed on `main` first, then cherry-picked into the most recent tagged release when needed.
+
+## Reporting a Vulnerability
+
+1. **Use GitHub Security Advisories (preferred):**
+   - Navigate to the repository Security tab → “Report a vulnerability”.
+   - Provide a minimal reproduction, impacted versions, and suggested fixes if available.
+2. **Email fallback:**
+   - If you cannot access GitHub, email `guesswho@rizzn.com` with the subject line `SECURITY REPORT: courtlistener-sdk`.
+   - Encrypt with PGP if desired (key fingerprints available on request).
+
+Please avoid creating public issues or pull requests for unresolved vulnerabilities. We will coordinate a private fix and disclosure timeline with you before anything is published.
+
+## Response & Remediation SLAs
+
+| Severity | Acknowledgement | Initial Fix ETA |
+|----------|-----------------|-----------------|
+| Critical | 24 hours        | 7 days          |
+| High     | 2 business days | 14 days         |
+| Medium   | 5 business days | 30 days         |
+| Low      | 5 business days | Best effort     |
+
+We will keep reporters updated weekly (or more frequently for Critical issues) until remediation is available.
+
+## Automated Security Tooling
+
+- `Security Audits` workflow runs `pip-audit` and `composer audit` on every push/PR and nightly, ensuring dependency advisories fail fast.
+- `CodeQL` workflow runs static analysis for both the Python and PHP SDKs. Findings surface in the GitHub Security tab and block regressions via pull-request annotations.
+- Dependabot is enabled for the `pip` and Composer ecosystems to keep transitive dependencies patched via automated PRs.
+
+If you need more information about a specific security control or would like to coordinate on disclosure timing, please email us at `guesswho@rizzn.com`.

--- a/php/composer.json
+++ b/php/composer.json
@@ -22,11 +22,11 @@
     ],
     "require": {
         "php": ">=8.1",
-        "guzzlehttp/guzzle": "*",
-        "vlucas/phpdotenv": "*"
+        "guzzlehttp/guzzle": "7.10.0",
+        "vlucas/phpdotenv": "5.6.2"
     },
     "require-dev": {
-        "phpstan/phpstan": "*",
+        "phpstan/phpstan": "2.1.28",
         "phpunit/phpunit": "^10.0"
     },
     "autoload": {

--- a/php/composer.lock
+++ b/php/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d52d47865c98a0fab8e19a70036a5105",
+    "content-hash": "6d9e4a141ab259cf2faa002b298f3eff",
     "packages": [
         {
             "name": "graham-campbell/result-type",
@@ -2802,5 +2802,5 @@
         "php": ">=8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.28.0
-typing-extensions>=4.0.0
-python-dotenv>=1.0.0 
+requests>=2.28.0,<3.0.0
+typing-extensions>=4.0.0,<5.0.0
+python-dotenv>=1.0.0,<2.0.0


### PR DESCRIPTION
## Summary
- pin PHP dependencies to their locked versions, cap Python requirements, and refresh the Composer lockfile (resolves #30)
- add Dependabot plus pip/composer audit and CodeQL workflows so security advisories surface automatically (resolves #6)
- publish SECURITY.md with disclosure SLAs and tie the automation together for a documented vulnerability process (resolves #11)

## Testing
- composer test-unit
- python3 -m pip_audit -r python/requirements.txt
- ./composer audit --no-interaction
- source .venv/bin/activate && yamllint .github/workflows/security-audit.yml .github/workflows/codeql.yml