### PR TITLE
Add Makefile tooling for repo workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+SHELL := /bin/bash
+
+PYTHON ?= python3
+PHP ?= php
+COMPOSER ?= composer
+
+PYTHON_DIR := python
+PHP_DIR := php
+DOCS_DIR := docs
+TOOLS_DIR := tools
+DIST_DIR := dist
+
+.DEFAULT_GOAL := help
+
+.PHONY: help bootstrap lint test build docs release clean \
+	python-lint python-test python-build python-docs python-release \
+	php-lint php-test php-build php-docs php-release
+
+help: ## Print available targets
+	@printf "Available targets:\n"
+	@grep -E '^[a-zA-Z0-9_.-]+:.*##' Makefile | awk 'BEGIN {FS=":.*##"} {printf "  %-18s %s\n", $$1, $$2}'
+
+bootstrap: ## Install dev dependencies for both SDKs
+	cd $(PYTHON_DIR) && $(PYTHON) -m pip install --upgrade pip
+	cd $(PYTHON_DIR) && $(PYTHON) -m pip install -e ".[dev]"
+	cd $(PHP_DIR) && $(COMPOSER) install
+
+lint: python-lint php-lint ## Run all linters
+
+python-lint: ## Run Python formatters and static analysis
+	cd $(PYTHON_DIR) && $(PYTHON) -m black --check courtlistener tests
+	cd $(PYTHON_DIR) && $(PYTHON) -m flake8 courtlistener tests
+	cd $(PYTHON_DIR) && $(PYTHON) -m mypy courtlistener
+
+php-lint: ## Run PHPStan analysis
+	cd $(PHP_DIR) && $(COMPOSER) stan
+
+test: python-test php-test ## Run the full test suites
+
+python-test: ## Run Python tests
+	cd $(PYTHON_DIR) && $(PYTHON) -m pytest
+
+php-test: ## Run PHP tests
+	cd $(PHP_DIR) && $(COMPOSER) test
+
+build: python-build php-build ## Build distributable artifacts
+
+python-build: ## Build Python packages (sdist/wheel)
+	cd $(PYTHON_DIR) && $(PYTHON) -m build
+
+php-build: ## Optimize Composer autoloader
+	cd $(PHP_DIR) && $(COMPOSER) install
+	cd $(PHP_DIR) && $(COMPOSER) dump-autoload -o
+
+docs: python-docs php-docs ## Validate documentation links
+
+python-docs: ## Validate docs referencing the Python SDK
+	$(PYTHON) $(TOOLS_DIR)/check_docs.py $(DOCS_DIR) $(PYTHON_DIR)/README.md
+
+php-docs: ## Validate docs referencing the PHP SDK
+	$(PYTHON) $(TOOLS_DIR)/check_docs.py $(DOCS_DIR) $(PHP_DIR)/README.md
+
+release: python-release php-release ## Run release preparation steps
+
+python-release: python-build ## Validate Python artifacts with Twine
+	cd $(PYTHON_DIR) && $(PYTHON) -m twine check dist/*
+
+php-release: php-build ## Package PHP SDK as a zip archive
+	cd $(PHP_DIR) && $(COMPOSER) validate --strict
+	mkdir -p $(DIST_DIR)/php
+	cd $(PHP_DIR) && $(COMPOSER) archive --format=zip --dir=../$(DIST_DIR)/php --file=courtlistener-php
+
+clean: ## Remove build and cache artifacts
+	rm -rf $(PYTHON_DIR)/.pytest_cache $(PYTHON_DIR)/.mypy_cache $(PYTHON_DIR)/build $(PYTHON_DIR)/dist
+	rm -rf $(PHP_DIR)/vendor $(PHP_DIR)/.phpunit.result.cache $(DIST_DIR)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ foreach ($dockets['results'] as $docket) {
 }
 ```
 
+## Development Tooling
+
+Run these repo-root targets to keep both SDKs in sync:
+
+| Command | Purpose |
+|---------|---------|
+| `make bootstrap` | Install Python dev extras (`pip install -e ".[dev]"`) and PHP Composer deps. |
+| `make lint` | Run `black`, `flake8`, `mypy`, and `phpstan` in one go. Use `python-lint`/`php-lint` for individual SDKs. |
+| `make test` | Execute `pytest` and `composer test`. |
+| `make build` | Produce Python sdists/wheels (`python -m build`) and optimize Composer autoloaders. |
+| `make docs` | Validate Markdown links across `docs/` plus each language README via `tools/check_docs.py`. |
+| `make release` | Sanity-check Python artifacts with `twine check` and package the PHP SDK as a zip via `composer archive`. |
+| `make clean` | Remove virtualenv caches, build artifacts, and Composer vendor installs. |
+
+All targets accept the usual overrides (e.g., `PYTHON=python3.12 make python-test`). Use `make help` to list every available command.
+
 ## Available Endpoints
 
 Both Python and PHP SDKs provide access to all CourtListener API endpoints:

--- a/python/setup.py
+++ b/python/setup.py
@@ -55,6 +55,8 @@ setup(
             "flake8>=5.0.0",
             "mypy>=1.0.0",
             "isort>=5.0.0",
+            "build>=1.0.3",
+            "twine>=4.0.0",
         ],
     },
     keywords="legal, court, api, sdk, courtlistener, case law, dockets, judges, unofficial",

--- a/tools/check_docs.py
+++ b/tools/check_docs.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Simple Markdown link validator for internal documentation."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+INLINE_LINK_RE = re.compile(r"!?\[[^\]]+\]\(([^)]+)\)")
+REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+]:\s*(\S+)", re.MULTILINE)
+SKIP_PREFIXES = ("http://", "https://", "mailto:", "tel:", "#", "data:", "javascript:")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate that local Markdown links point to existing files."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Markdown files or directories containing Markdown files to check.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print every processed link for debugging.",
+    )
+    return parser.parse_args()
+
+
+def iter_markdown_files(paths: Sequence[str]) -> Iterable[Path]:
+    for raw_path in paths:
+        path = Path(raw_path).resolve()
+        if not path.exists():
+            raise FileNotFoundError(f"{raw_path} does not exist")
+        if path.is_dir():
+            yield from sorted(path.rglob("*.md"))
+        elif path.suffix.lower() == ".md":
+            yield path
+
+
+def extract_targets(markdown: str) -> Iterable[str]:
+    for match in INLINE_LINK_RE.finditer(markdown):
+        yield match.group(1).strip()
+    for match in REFERENCE_LINK_RE.finditer(markdown):
+        yield match.group(1).strip()
+
+
+def normalize_target(raw_target: str) -> str | None:
+    target = raw_target.strip()
+    if not target or target.startswith(SKIP_PREFIXES):
+        return None
+    if target.startswith("<") and target.endswith(">"):
+        target = target[1:-1].strip()
+    if target.startswith(SKIP_PREFIXES) or not target:
+        return None
+
+    # Drop optional title sections: path "Some Title"
+    if " " in target and not target.startswith(("http://", "https://")):
+        target = target.split()[0]
+
+    # Remove anchors or query strings.
+    target = target.split("#", 1)[0]
+    target = target.split("?", 1)[0]
+    if not target or target.startswith(SKIP_PREFIXES):
+        return None
+    if target.startswith("{#"):
+        return None
+    return target
+
+
+def validate_links(paths: Sequence[str], verbose: bool = False) -> Tuple[int, List[str]]:
+    files = list(iter_markdown_files(paths))
+    missing: List[str] = []
+    checked = 0
+
+    for file_path in files:
+        contents = file_path.read_text(encoding="utf-8")
+        for target in extract_targets(contents):
+            normalized = normalize_target(target)
+            if not normalized:
+                continue
+            resolved = (file_path.parent / normalized).resolve()
+            checked += 1
+            if verbose:
+                print(f"[check] {file_path.relative_to(Path.cwd())} -> {normalized}")
+            if not resolved.exists():
+                missing.append(
+                    f"{file_path.relative_to(Path.cwd())}: missing target '{normalized}'"
+                )
+    return checked, missing
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        checked_count, missing_links = validate_links(args.paths, args.verbose)
+    except FileNotFoundError as exc:
+        print(f"[docs] {exc}", file=sys.stderr)
+        return 2
+
+    if missing_links:
+        print("[docs] Broken documentation links detected:")
+        for problem in missing_links:
+            print(f"  - {problem}")
+        print(f"[docs] Checked {checked_count} link(s).", file=sys.stderr)
+        return 1
+
+    print(f"[docs] All good — validated {checked_count} link(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a repo-root Makefile so python/php lint, test, build, docs, and release flows share the same entry points
- add a docs link validator script wired into the new `make docs` target and surface the workflow in the README
- extend the python dev extra with build/twine so release targets work after `make bootstrap`

Fixes #12.

## Testing
- `make docs`
- `COURTLISTENER_API_TOKEN=7c2ad11c595dcb088f23d7a757190c47e8f397a2 make test` *(fails: 79 pre-existing integration/mocks/model tests due to API responses returning dataclasses and permission/shape differences, e.g. `tests/integration/test_all_endpoints.py::TestCourtsIntegration::test_list_courts` where the client now returns `Court` objects, plus `tests/test_client.py::test_client_initialization_without_token` expecting an exception that no longer fires)*
- `COMPOSER_PROCESS_TIMEOUT=0 COURTLISTENER_API_TOKEN=7c2ad11c595dcb088f23d7a757190c47e8f397a2 composer test` *(fails: 137 live tests report 403/404/not-found responses for secured endpoints even with the shared token, e.g. `CourtListener\\Tests\\Live\\AbaRatingsLiveTest::testSearchAbaRatings` and other live suites that require elevated API permissions, plus 14 pagination expectation mismatches in `CourtListener\\Tests\\Live\\LiveApiTest`)*