### PR TITLE
Fix #18: surface custom timeout/connection errors

### DIFF
--- a/python/courtlistener/client.py
+++ b/python/courtlistener/client.py
@@ -5,8 +5,8 @@ Main client class for the CourtListener SDK.
 import time
 import requests
 import logging
-from typing import Dict, Any, Optional, Union
-from urllib.parse import urljoin, urlencode
+from typing import Dict, Any, Optional
+from urllib.parse import urljoin
 
 from .config import Config
 from .exceptions import (
@@ -234,14 +234,22 @@ class CourtListenerClient:
                 response = self.session.request(method, url, **request_kwargs)
                 return self._handle_response(response)
             
-            except requests.exceptions.Timeout:
+            except requests.exceptions.Timeout as exc:
                 if attempt == self.config.max_retries:
-                    raise CourtListenerError("Request timed out")
+                    detail = str(exc).strip()
+                    message = "Request timed out"
+                    if detail:
+                        message = f"{message}: {detail}"
+                    raise TimeoutError(message)
                 time.sleep(self.config.retry_delay)
             
-            except requests.exceptions.ConnectionError:
+            except requests.exceptions.ConnectionError as exc:
                 if attempt == self.config.max_retries:
-                    raise CourtListenerError("Failed to connect to API")
+                    detail = str(exc).strip()
+                    message = "Failed to connect to API"
+                    if detail:
+                        message = f"{message}: {detail}"
+                    raise ConnectionError(message)
                 time.sleep(self.config.retry_delay)
             
             except requests.exceptions.RequestException as e:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -96,12 +96,12 @@ def test_client_make_request_timeout():
     """Test _make_request with timeout error."""
     from unittest.mock import Mock, patch
     import requests
-    from courtlistener.exceptions import CourtListenerError
+    from courtlistener.exceptions import TimeoutError
     
     client = CourtListenerClient(api_token="test_token")
     
     with patch.object(client.session, 'request', side_effect=requests.exceptions.Timeout("Request timed out")):
-        with pytest.raises(CourtListenerError, match="Request timed out"):
+        with pytest.raises(TimeoutError, match="Request timed out"):
             client._make_request('GET', 'test/endpoint')
 
 
@@ -109,12 +109,12 @@ def test_client_make_request_connection_error():
     """Test _make_request with connection error."""
     from unittest.mock import Mock, patch
     import requests
-    from courtlistener.exceptions import CourtListenerError
+    from courtlistener.exceptions import ConnectionError
     
     client = CourtListenerClient(api_token="test_token")
     
     with patch.object(client.session, 'request', side_effect=requests.exceptions.ConnectionError("Connection failed")):
-        with pytest.raises(CourtListenerError, match="Failed to connect to API"):
+        with pytest.raises(ConnectionError, match="Failed to connect to API"):
             client._make_request('GET', 'test/endpoint')
 
 

--- a/python/tests/test_client/test_client_comprehensive.py
+++ b/python/tests/test_client/test_client_comprehensive.py
@@ -341,7 +341,7 @@ class TestCourtListenerClient:
         """Test behavior when max retries are exceeded."""
         mock_request.side_effect = requests.exceptions.Timeout("Timeout")
 
-        with pytest.raises(CourtListenerError, match="Request timed out"):
+        with pytest.raises(TimeoutError, match="Request timed out"):
             self.client._make_request('GET', 'courts/')
 
     @patch('requests.Session.request')
@@ -349,7 +349,7 @@ class TestCourtListenerClient:
         """Test connection error when max retries exceeded."""
         mock_request.side_effect = requests.exceptions.ConnectionError("Connection failed")
 
-        with pytest.raises(CourtListenerError, match="Failed to connect to API"):
+        with pytest.raises(ConnectionError, match="Failed to connect to API"):
             self.client._make_request('GET', 'courts/')
 
     @patch('requests.Session.request')

--- a/python/tests/test_client_comprehensive.py
+++ b/python/tests/test_client_comprehensive.py
@@ -195,7 +195,7 @@ class TestCourtListenerClientComprehensive:
         ]
         
         with patch('time.sleep') as mock_sleep:
-            with pytest.raises(CourtListenerError) as exc_info:
+            with pytest.raises(TimeoutError) as exc_info:
                 self.client._make_request('GET', 'courts/')
             
             assert "Request timed out" in str(exc_info.value)
@@ -211,7 +211,7 @@ class TestCourtListenerClientComprehensive:
         ]
         
         with patch('time.sleep') as mock_sleep:
-            with pytest.raises(CourtListenerError) as exc_info:
+            with pytest.raises(ConnectionError) as exc_info:
                 self.client._make_request('GET', 'courts/')
             
             assert "Failed to connect to API" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- drop the unused urllib and typing imports from the python client
- raise the SDK-specific TimeoutError/ConnectionError after exhausting retries so callers can handle them explicitly
- update the client test suites to assert on the new exception types and messages

## Test plan
- python3 -m pytest -o addopts='' tests/test_client.py tests/test_client_comprehensive.py tests/test_client/test_client_comprehensive.py