### PR TITLE
feat: Add default HTTP timeouts (10s) and preserve exception context

### DIFF
--- a/php/src/CourtListener/CourtListenerClient.php
+++ b/php/src/CourtListener/CourtListenerClient.php
@@ -130,7 +130,7 @@ class CourtListenerClient
         // Set configuration
         $this->baseUrl = $config['base_url'] ?? $_ENV['COURTLISTENER_BASE_URL'] ?? 'https://www.courtlistener.com/api/rest/v4/';
         $this->apiToken = $config['api_token'] ?? $_ENV['COURTLISTENER_API_TOKEN'] ?? '';
-        $this->timeout = $config['timeout'] ?? 30;
+        $this->timeout = $config['timeout'] ?? 10;
         $this->maxRetries = $config['max_retries'] ?? 3;
         $this->retryDelay = $config['retry_delay'] ?? 1.0;
 
@@ -270,7 +270,9 @@ class CourtListenerClient
                     sleep($this->retryDelay * $attempt);
                     continue;
                 }
-                throw new CourtListenerException('Connection error: ' . $e->getMessage());
+                $exception = new CourtListenerException('Connection error: ' . $e->getMessage());
+                $exception->setPrevious($e);
+                throw $exception;
             } catch (GuzzleException $e) {
                 throw new CourtListenerException('Request failed: ' . $e->getMessage());
             }

--- a/python/courtlistener/client.py
+++ b/python/courtlistener/client.py
@@ -240,7 +240,7 @@ class CourtListenerClient:
                     message = "Request timed out"
                     if detail:
                         message = f"{message}: {detail}"
-                    raise TimeoutError(message)
+                    raise TimeoutError(message) from exc
                 time.sleep(self.config.retry_delay)
             
             except requests.exceptions.ConnectionError as exc:
@@ -249,7 +249,7 @@ class CourtListenerClient:
                     message = "Failed to connect to API"
                     if detail:
                         message = f"{message}: {detail}"
-                    raise ConnectionError(message)
+                    raise ConnectionError(message) from exc
                 time.sleep(self.config.retry_delay)
             
             except requests.exceptions.RequestException as e:

--- a/python/courtlistener/config.py
+++ b/python/courtlistener/config.py
@@ -19,7 +19,7 @@ class Config:
     
     # Default settings
     DEFAULT_BASE_URL = "https://www.courtlistener.com/api/rest/v4/"
-    DEFAULT_TIMEOUT = 30
+    DEFAULT_TIMEOUT = 10
     DEFAULT_MAX_RETRIES = 3
     DEFAULT_RETRY_DELAY = 1
     DEFAULT_RATE_LIMIT_DELAY = 1


### PR DESCRIPTION
This PR adds default HTTP timeouts (10 seconds) and preserves exception context in both Python and PHP implementations.

## Changes

### Python
- ✅ Changed default timeout from 30s to 10s in `Config.DEFAULT_TIMEOUT`
- ✅ Preserved exception context using `raise ... from exc` for TimeoutError and ConnectionError
- ✅ Timeout is configurable via constructor parameter

### PHP
- ✅ Changed default timeout from 30s to 10s
- ✅ Preserved exception context using `setPrevious()` for connection errors
- ✅ Timeout is configurable via config array

## Benefits

- **Sensible Defaults**: 10 second timeout prevents hanging requests
- **Exception Context**: Original exceptions are preserved, making debugging easier
- **Configurable**: Timeouts can still be overridden when needed

Fixes #4

