### PR TITLE
refactor(python): Consolidate error handling - remove duplicate _handle_error

### DIFF
--- a/python/courtlistener/client.py
+++ b/python/courtlistener/client.py
@@ -275,23 +275,23 @@ class CourtListenerClient:
         Raises:
             Various CourtListenerError subclasses based on response status
         """
-        if response.status_code == 200:
+        # Handle successful responses (2xx)
+        if 200 <= response.status_code < 300:
             return response.json()
         
-        elif response.status_code == 401:
+        # Handle error responses
+        if response.status_code == 401:
             raise AuthenticationError("Invalid API token")
-        
+        elif response.status_code == 403:
+            raise AuthenticationError("Access forbidden")
         elif response.status_code == 404:
             raise NotFoundError("Resource not found")
-        
         elif response.status_code == 429:
             # Rate limited - wait and retry
             time.sleep(self.config.rate_limit_delay)
             raise RateLimitError("Rate limit exceeded")
-        
         elif response.status_code >= 500:
             raise APIError(f"Server error: {response.status_code}")
-        
         else:
             # Try to get error message from response
             try:
@@ -339,21 +339,6 @@ class CourtListenerClient:
             return True
         except Exception as e:
             raise CourtListenerError(f"Connection test failed: {str(e)}")
-    
-    def _handle_error(self, response):
-        """Handle API errors."""
-        if response.status_code == 401:
-            raise AuthenticationError("Invalid API token")
-        elif response.status_code == 403:
-            raise AuthenticationError("Access forbidden")
-        elif response.status_code == 404:
-            raise NotFoundError("Resource not found")
-        elif response.status_code == 429:
-            raise RateLimitError("Rate limit exceeded")
-        elif response.status_code >= 500:
-            raise APIError(f"Server error: {response.status_code}")
-        else:
-            raise APIError(f"API error: {response.status_code}")
     
     def __repr__(self) -> str:
         """String representation of the client."""

--- a/python/tests/test_client/test_client_comprehensive.py
+++ b/python/tests/test_client/test_client_comprehensive.py
@@ -433,7 +433,7 @@ class TestCourtListenerClient:
         mock_response.status_code = 401
         
         with pytest.raises(AuthenticationError, match="Invalid API token"):
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
 
     def test_handle_error_403(self):
         """Test _handle_error with 403 status."""
@@ -441,7 +441,7 @@ class TestCourtListenerClient:
         mock_response.status_code = 403
         
         with pytest.raises(AuthenticationError, match="Access forbidden"):
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
 
     def test_handle_error_404(self):
         """Test _handle_error with 404 status."""
@@ -449,7 +449,7 @@ class TestCourtListenerClient:
         mock_response.status_code = 404
         
         with pytest.raises(NotFoundError, match="Resource not found"):
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
 
     def test_handle_error_429(self):
         """Test _handle_error with 429 status."""
@@ -457,7 +457,7 @@ class TestCourtListenerClient:
         mock_response.status_code = 429
         
         with pytest.raises(RateLimitError, match="Rate limit exceeded"):
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
 
     def test_handle_error_500(self):
         """Test _handle_error with 500 status."""
@@ -465,7 +465,7 @@ class TestCourtListenerClient:
         mock_response.status_code = 500
         
         with pytest.raises(APIError, match="Server error: 500"):
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
 
     def test_handle_error_other(self):
         """Test _handle_error with other status."""
@@ -473,7 +473,7 @@ class TestCourtListenerClient:
         mock_response.status_code = 400
         
         with pytest.raises(APIError, match="API error: 400"):
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
 
     def test_repr(self):
         """Test __repr__ method."""

--- a/python/tests/test_client_comprehensive.py
+++ b/python/tests/test_client_comprehensive.py
@@ -409,7 +409,7 @@ class TestCourtListenerClientComprehensive:
         mock_response.status_code = 401
         
         with pytest.raises(AuthenticationError) as exc_info:
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
         
         assert "Invalid API token" in str(exc_info.value)
     
@@ -419,7 +419,7 @@ class TestCourtListenerClientComprehensive:
         mock_response.status_code = 403
         
         with pytest.raises(AuthenticationError) as exc_info:
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
         
         assert "Access forbidden" in str(exc_info.value)
     
@@ -429,7 +429,7 @@ class TestCourtListenerClientComprehensive:
         mock_response.status_code = 404
         
         with pytest.raises(NotFoundError) as exc_info:
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
         
         assert "Resource not found" in str(exc_info.value)
     
@@ -439,7 +439,7 @@ class TestCourtListenerClientComprehensive:
         mock_response.status_code = 429
         
         with pytest.raises(RateLimitError) as exc_info:
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
         
         assert "Rate limit exceeded" in str(exc_info.value)
     
@@ -449,7 +449,7 @@ class TestCourtListenerClientComprehensive:
         mock_response.status_code = 500
         
         with pytest.raises(APIError) as exc_info:
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
         
         assert "Server error: 500" in str(exc_info.value)
     
@@ -459,7 +459,7 @@ class TestCourtListenerClientComprehensive:
         mock_response.status_code = 418
         
         with pytest.raises(APIError) as exc_info:
-            self.client._handle_error(mock_response)
+            self.client._handle_response(mock_response)
         
         assert "API error: 418" in str(exc_info.value)
     


### PR DESCRIPTION
This PR consolidates error handling by removing the duplicate `_handle_error` method.

## Changes

### Error Handling Consolidation
- ✅ Removed `_handle_error` method (duplicate of `_handle_response` logic)
- ✅ Enhanced `_handle_response` to handle all status codes:
  - 2xx: Success responses
  - 401: AuthenticationError
  - 403: AuthenticationError (added, was only in _handle_error)
  - 404: NotFoundError
  - 429: RateLimitError
  - 5xx: APIError
  - Other: APIError with error message from response
- ✅ Updated tests to use `_handle_response` instead of `_handle_error`

## Benefits

- **Single Code Path**: All error handling goes through `_handle_response`
- **No Duplication**: Removed duplicate logic that could get out of sync
- **Easier Maintenance**: One place to update error handling logic
- **Better Coverage**: Added 403 handling that was missing from `_handle_response`

Fixes #17

