### PR TITLE
Make citation and docket_number validators stricter (#22)

### DIFF
--- a/python/tests/test_api/test_dockets_comprehensive.py
+++ b/python/tests/test_api/test_dockets_comprehensive.py
@@ -133,7 +133,8 @@ class TestDocketsAPIComprehensive:
         mock_response = {"results": []}
         self.mock_client.get.return_value = mock_response
         
-        result = self.api.get_docket_by_number("nonexistent")
+        # Use a valid docket number format that doesn't exist
+        result = self.api.get_docket_by_number("99-99999")
         
         assert result is None
     

--- a/python/tests/test_utils/test_validators.py
+++ b/python/tests/test_utils/test_validators.py
@@ -99,9 +99,9 @@ class TestValidateCitation:
         assert result is True
 
     def test_validate_citation_non_standard(self):
-        """Test non-standard citation (should still pass)."""
-        result = validate_citation('Some random citation format')
-        assert result is True
+        """Test non-standard citation (should fail)."""
+        with pytest.raises(ValidationError, match="Invalid citation format"):
+            validate_citation('Some random citation format')
 
 
 class TestValidateDocketNumber:
@@ -138,9 +138,9 @@ class TestValidateDocketNumber:
             validate_docket_number(None)
 
     def test_validate_docket_number_non_standard(self):
-        """Test non-standard docket number (should still pass)."""
-        result = validate_docket_number('ABC-123-XYZ')
-        assert result is True
+        """Test non-standard docket number (should fail)."""
+        with pytest.raises(ValidationError, match="Invalid docket number format"):
+            validate_docket_number('ABC-123-XYZ')
 
 
 class TestValidateCourtId:


### PR DESCRIPTION
## Make citation and docket_number validators stricter

Fixes #22

### Problem
The `validate_citation` and `validate_docket_number` functions were always returning `True` even when input didn't match any known pattern, making validation useless.

### Solution
**Made validators strict by raising ValidationError when patterns don't match:**

1. **`validate_citation`**:
   - Expanded pattern coverage for common citation formats:
     - SCOTUS: "576 U.S. 644" or "576 US 644"
     - Federal Reporter: "123 F.3d 456", "123 F3d 456", "123 F. 3d 456"
     - Federal Supplement: "123 F.Supp. 456", "123 F Supp 456"
     - Federal Appendix: "123 F.App'x 456"
     - State citations: "123 Cal. 3d 456", "123 N.Y. 456"
   - Removed permissive `return True` fallback
   - Raises `ValidationError` with descriptive message when no pattern matches

2. **`validate_docket_number`**:
   - Expanded pattern coverage for common docket formats:
     - SCOTUS: "21-123"
     - Federal District: "1:21-cv-12345", "1-21-cv-12345" (with various case types: cv, cr, mc, md, mi, mj, bk, ap)
     - Federal Circuit: "21-1234"
     - State: "CR-21-12345", "CV-2021-12345"
     - Simple numeric: "12345"
   - Removed permissive `return True` fallback
   - Raises `ValidationError` with descriptive message when no pattern matches

3. **Updated tests**:
   - Removed tests expecting non-standard formats to pass
   - Added comprehensive tests for invalid formats that should fail
   - Fixed `test_get_docket_by_number_not_found` to use valid docket number format
   - All 112 validator tests passing
   - **100% test coverage for validators.py module**

### Benefits
- Validators actually validate input instead of always passing
- Better error messages for invalid input
- Prevents invalid data from being sent to API
- More maintainable and reliable codebase

### Test Coverage
- **validators.py**: 100% coverage
- All 112 validator tests passing
- Comprehensive tests for both valid and invalid formats

